### PR TITLE
Added synchronization to fix NPE bug in MessageHandler

### DIFF
--- a/build.gradle
+++ b/build.gradle
@@ -1,6 +1,6 @@
 import java.text.SimpleDateFormat;
 
-def jkind_version_base = '4.5.1'
+def jkind_version_base = '4.5.2'
 
 def buildTime() {
     def df = new SimpleDateFormat("yyyyMMddHHmm");


### PR DESCRIPTION
MWW, 8/27/2022
This PR fixes an occasional NPE bug that we have seen in jkind in the MessageHandler class.  Within the class, the 
receiveMessage and stopReceivingMessages methods run on different threads, leading to occasional NPE exceptions due to race conditions when solver is completing analyses.  

NPEs happen when incoming is checked for null, but then receiveMessage thread is interrupted and incoming is set to null by stopReceivingMessages prior to incoming.add(message).

Note that other protected functions do not need to be synchronized because they are called on the same thread as stopReceivingMessages. 

The fix was tested by running several of the tests in the jkind testing directory looking for possible deadlocks and performance changes.  We also ran models that occasionally lead to NPEs that are internal.  There is a slight performance hit using synchronized for message passing (a few % of execution, depending on the problem), and no deadlocks occurred.  Furthermore, no NPEs were observed.